### PR TITLE
Breaking: handle destroyed objects

### DIFF
--- a/Assets/Scripts/Saves/LoadableCube.cs
+++ b/Assets/Scripts/Saves/LoadableCube.cs
@@ -1,26 +1,28 @@
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using TaloGameServices;
 
 public class LoadableCube : Loadable
 {
     public override void RegisterFields()
     {
-        savedFields.Add("x", transform.position.x);
-        savedFields.Add("y", transform.position.y);
-        savedFields.Add("z", transform.position.z);
+        RegisterField("x", transform.position.x);
+        RegisterField("y", transform.position.y);
+        RegisterField("z", transform.position.z);
 
-        savedFields.Add("r.x", transform.rotation.x);
-        savedFields.Add("r.y", transform.rotation.y);
-        savedFields.Add("r.z", transform.rotation.z);
+        RegisterField("r.x", transform.rotation.x);
+        RegisterField("r.y", transform.rotation.y);
+        RegisterField("r.z", transform.rotation.z);
 
-        savedFields.Add("s.x", transform.localScale.x);
-        savedFields.Add("s.y", transform.localScale.y);
-        savedFields.Add("s.z", transform.localScale.z);
+        RegisterField("s.x", transform.localScale.x);
+        RegisterField("s.y", transform.localScale.y);
+        RegisterField("s.z", transform.localScale.z);
     }
 
     public override void OnLoaded(Dictionary<string, object> data)
     {
+        if (HandleDestroyed(data)) return;
+
         transform.position = new Vector3(
             (float)data["x"],
             (float)data["y"],

--- a/Packages/com.trytalo.talo/Runtime/Entities/Loadable.cs
+++ b/Packages/com.trytalo.talo/Runtime/Entities/Loadable.cs
@@ -1,36 +1,57 @@
 using System;
 using UnityEngine;
-using TaloGameServices;
 using System.Collections.Generic;
 
-public class Loadable : MonoBehaviour, ILoadable
+namespace TaloGameServices
 {
-    public string id = Guid.NewGuid().ToString();
-    public Dictionary<string, object> savedFields = new Dictionary<string, object>();
-
-    protected virtual void OnEnable()
+    public class Loadable : MonoBehaviour, ILoadable
     {
-        Talo.Saves.Register(this);
-        Talo.Saves.OnSaveChosen += LoadData;
-    }
+        private string _id = Guid.NewGuid().ToString();
 
-    protected virtual void OnDisable()
-    {
-        Talo.Saves.OnSaveChosen -= LoadData;
-    }
+        private Dictionary<string, object> _savedFields = new Dictionary<string, object>();
 
-    private void LoadData(GameSave save)
-    {
-        OnLoaded(Talo.Saves.LoadObject(save, id));
-    }
+        public string Id => _id;
 
-    public virtual void RegisterFields()
-    {
-        throw new NotImplementedException();
-    }
+        public Dictionary<string, object> SavedFields => _savedFields;
 
-    public virtual void OnLoaded(Dictionary<string, object> data)
-    {
-        throw new NotImplementedException();
+        protected virtual void OnEnable()
+        {
+            Talo.Saves.Register(this);
+            Talo.Saves.OnSaveChosen += LoadData;
+        }
+
+        protected virtual void OnDisable()
+        {
+            Talo.Saves.OnSaveChosen -= LoadData;
+        }
+
+        private void LoadData(GameSave save)
+        {
+            var data = Talo.Saves.LoadObject(save, _id);
+            if (data != null) OnLoaded(data);
+        }
+
+        public virtual void RegisterFields()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected void RegisterField(string key, object value)
+        {
+            _savedFields.Add(key, value);
+        }
+
+        public virtual void OnLoaded(Dictionary<string, object> data)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected bool HandleDestroyed(Dictionary<string, object> data)
+        {
+            data.TryGetValue("meta.destroyed", out var destroyed);
+            if (destroyed != null) Destroy(gameObject);
+
+            return destroyed != null;
+        }
     }
 }

--- a/Packages/com.trytalo.talo/Runtime/Entities/LoadableData.cs
+++ b/Packages/com.trytalo.talo/Runtime/Entities/LoadableData.cs
@@ -1,0 +1,23 @@
+﻿namespace TaloGameServices
+{
+    public struct LoadableData
+    {
+        public readonly string id;
+        public readonly Loadable loadable;
+        public readonly string name;
+
+        public LoadableData(Loadable loadable)
+        {
+            id = loadable.Id;
+            this.loadable = loadable;
+
+            var go = loadable.gameObject;
+            name = go.name;
+            while (go.transform.parent != null)
+            {
+                go = go.transform.parent.gameObject;
+                name = $"{go.name}.{name}";
+            }
+        }
+    }
+}

--- a/Packages/com.trytalo.talo/Runtime/Entities/LoadableData.cs.meta
+++ b/Packages/com.trytalo.talo/Runtime/Entities/LoadableData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d74127bcce07764dac486f7cd18be34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.trytalo.talo/Runtime/Entities/SaveContent.cs
+++ b/Packages/com.trytalo.talo/Runtime/Entities/SaveContent.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 
 namespace TaloGameServices
 {
@@ -19,31 +18,35 @@ namespace TaloGameServices
         public string name;
         public SavedObjectData[] data;
 
-        public SavedObject(Loadable loadable)
+        public SavedObject(LoadableData loadableData)
         {
-            id = loadable.id;
+            id = loadableData.id;
+            name = loadableData.name;
 
-            name = GetFullName(loadable.gameObject);
-
-            data = loadable.savedFields.Select((field) => new SavedObjectData()
+            if (loadableData.loadable != null)
             {
-                key = field.Key,
-                value = field.Value.ToString(),
-                type = field.Value.GetType().ToString()
-            }).ToArray();
-        }
+                loadableData.loadable.SavedFields.Clear();
+                loadableData.loadable.RegisterFields();
 
-        private string GetFullName(GameObject go)
-        {
-            var name = go.name;
-            while (go.transform.parent != null)
+                data = loadableData.loadable.SavedFields.Select((field) => new SavedObjectData()
+                {
+                    key = field.Key,
+                    value = field.Value.ToString(),
+                    type = field.Value.GetType().ToString()
+                }).ToArray();
+            } else
             {
-                go = go.transform.parent.gameObject;
-                name = $"{go.name}.{name}";
+                data = new SavedObjectData[]
+                {
+                    new SavedObjectData()
+                    {
+                        key = "meta.destroyed",
+                        value = "true",
+                        type = typeof(bool).ToString()
+                    }
+                };
             }
-            return name;
         }
-
     }
 
     [System.Serializable]
@@ -51,14 +54,10 @@ namespace TaloGameServices
     {
         public SavedObject[] objects;
 
-        public SaveContent(List<Loadable> loadables)
+        public SaveContent(List<LoadableData> loadables)
         {
             objects = loadables
-                .Select((loadable) =>
-                {
-                    loadable.RegisterFields();
-                    return new SavedObject(loadable);
-                })
+                .Select((loadable) => new SavedObject(loadable))
                 .ToArray();
         }
     }


### PR DESCRIPTION
Making the API more property-based and safer:

**API changes**
- `Loadable` is now correctly namespaced under `TaloGameServices`
- `savedFields` is no longer modifiable, instead use `RegisterField()` to add a field to the dictionary
- `savedFields` can now only be accessed via the `SavedFields` property
- `id` can now only be accessed via the `Id` property

**Destroyed objects**
- If an object is registered and then is found to be destroyed during saving, a `meta.destroyed` property becomes its only saved field
- The new `HandleDestroyed()` function will check for this key and destroy the object from the scene if it is present
