### PR TITLE
Remove the deprecated GetStat() function

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/StatsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/StatsAPI.cs
@@ -18,12 +18,6 @@ namespace TaloGameServices
             return res.stats;
         }
 
-        [Obsolete("Use Find(string internalName) instead.")]
-        public async Task<Stat> GetStat(string internalName)
-        {
-            return await Find(internalName);
-        }
-
         public async Task<Stat> Find(string internalName)
         {
             var uri = new Uri($"{baseUrl}/{internalName}");


### PR DESCRIPTION
**Deprecated API cleanup**
- Removed the obsolete `GetStat(string internalName)` method from `StatsAPI`, which had been deprecated in favor of `Find(string internalName)` — the two were functionally identical and the wrapper no longer served a purpose.