### PR TITLE
Remove the deprecated GetChannels(int page) signature

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
@@ -147,12 +147,6 @@ namespace TaloGameServices
             return res;
         }
 
-        [Obsolete("Use GetChannels(GetChannelsOptions options) instead.")]
-        public async Task<ChannelsIndexResponse> GetChannels(int page)
-        {
-            return await GetChannels(new GetChannelsOptions { page = page });
-        }
-
         public async Task<Channel[]> GetSubscribedChannels(GetSubscribedChannelsOptions options = null)
         {
             Talo.IdentityCheck();


### PR DESCRIPTION
**Deprecation cleanup**
- Removed the `[Obsolete]` `GetChannels(int page)` overload that was merely a thin wrapper around `GetChannels(GetChannelsOptions)`, consolidating the API surface to a single method with an options object.