### PR TITLE
Remove the deprecated CreatePrivate() channel function

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
@@ -212,19 +212,6 @@ namespace TaloGameServices
             return await SendCreateChannelRequest(options);
         }
 
-        [Obsolete("Use Create(CreateChannelOptions options) instead.")]
-        public async Task<Channel> CreatePrivate(string name, bool autoCleanup = false, params (string, string)[] propTuples)
-        {
-            var options = new CreateChannelOptions
-            {
-                name = name,
-                autoCleanup = autoCleanup,
-                props = propTuples,
-                isPrivate = true
-            };
-            return await SendCreateChannelRequest(options);
-        }
-
         public async Task<Channel> Join(int channelId)
         {
             Talo.IdentityCheck();


### PR DESCRIPTION
**API cleanup**

- Removed the `CreatePrivate` method from `ChannelsAPI.cs`, which was previously marked `[Obsolete]` and had been superseded by the unified `Create(CreateChannelOptions options)` overload — callers can now pass `isPrivate = true` in the options object instead of using a separate method.