### PR TITLE
Remove the deprecated Create overload for channels

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
@@ -199,19 +199,6 @@ namespace TaloGameServices
             return await SendCreateChannelRequest(options);
         }
 
-        [Obsolete("Use Create(CreateChannelOptions options) instead.")]
-        public async Task<Channel> Create(string name, bool autoCleanup = false, params (string, string)[] propTuples)
-        {
-            var options = new CreateChannelOptions
-            {
-                name = name,
-                autoCleanup = autoCleanup,
-                props = propTuples,
-                isPrivate = false
-            };
-            return await SendCreateChannelRequest(options);
-        }
-
         public async Task<Channel> Join(int channelId)
         {
             Talo.IdentityCheck();


### PR DESCRIPTION
**API surface cleanup**
- Removed the `[Obsolete]` overload of `ChannelsAPI.Create(string name, bool autoCleanup, params (string, string)[] propTuples)` that was deprecated in favor of the options-object-based `Create(CreateChannelOptions options)` overload