### PR TITLE
Remove the deprecated GetEntriesForCurrentPlayer() functions

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
@@ -85,17 +85,6 @@ namespace TaloGameServices
             return res;
         }
 
-        [Obsolete("Use GetEntries(string internalName, GetEntriesOptions options) with the aliasId or playerId option instead.")]
-        public async Task<LeaderboardEntriesResponse> GetEntriesForCurrentPlayer(string internalName, GetEntriesOptions options = null)
-        {
-            Talo.IdentityCheck();
-
-            options ??= new GetEntriesOptions();
-            options.aliasId = Talo.CurrentAlias.id;
-
-            return await GetEntries(internalName, options);
-        }
-
         [Obsolete("Use GetEntries(string internalName, GetEntriesOptions options) instead.")]
         public async Task<LeaderboardEntriesResponse> GetEntries(string internalName, int page, int aliasId = -1, bool includeArchived = false)
         {
@@ -105,19 +94,6 @@ namespace TaloGameServices
                 aliasId = aliasId,
                 includeArchived = includeArchived
             });
-        }
-
-        [Obsolete("Use GetEntries(string internalName, GetEntriesOptions options) with the aliasId or playerId option instead.")]
-        public async Task<LeaderboardEntriesResponse> GetEntriesForCurrentPlayer(string internalName, int page, bool includeArchived = false)
-        {
-            Talo.IdentityCheck();
-
-            return await GetEntries(internalName, new GetEntriesOptions
-            {
-                page = page,
-                aliasId = Talo.CurrentAlias.id,
-                includeArchived = includeArchived
-            }); 
         }
 
         public async Task<(LeaderboardEntry, bool)> AddEntry(string internalName, float score, params (string, string)[] propTuples)


### PR DESCRIPTION
**Deprecated method removal**
- Removed two `GetEntriesForCurrentPlayer` overloads from `LeaderboardsAPI` that were already marked `[Obsolete]`
- These methods were superseded by the `GetEntries(string, GetEntriesOptions)` overload, which accepts `aliasId` or `playerId` as part of the options parameter instead of implicitly using `Talo.CurrentAlias.id`