### PR TITLE
Remove the deprecated GetCacheEntriesForCurrentPlayer() function

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
@@ -60,14 +60,6 @@ namespace TaloGameServices
             );
         }
 
-        [Obsolete("Use GetCachedEntries(string internalName, GetCachedEntriesOptions options) with the aliasId or playerId option instead.")]
-        public List<LeaderboardEntry> GetCachedEntriesForCurrentPlayer(string internalName)
-        {
-            Talo.IdentityCheck();
-
-            return _entriesManager.GetEntries(internalName).FindAll(e => e.playerAlias.id == Talo.CurrentAlias.id);
-        }
-
         public async Task<LeaderboardEntriesResponse> GetEntries(string internalName, GetEntriesOptions options = null)
         {
             options ??= new GetEntriesOptions();


### PR DESCRIPTION
**API cleanup**
- Removed the deprecated `GetCachedEntriesForCurrentPlayer` method, which was previously replaced by the more flexible `GetCachedEntries(string internalName, GetCachedEntriesOptions options)` overload that accepts an `aliasId` or `playerId` option instead of implicitly filtering by the current player