### PR TITLE
Remove the deprecated GetEntries overload

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
@@ -77,17 +77,6 @@ namespace TaloGameServices
             return res;
         }
 
-        [Obsolete("Use GetEntries(string internalName, GetEntriesOptions options) instead.")]
-        public async Task<LeaderboardEntriesResponse> GetEntries(string internalName, int page, int aliasId = -1, bool includeArchived = false)
-        {
-            return await GetEntries(internalName, new GetEntriesOptions
-            {
-                page = page,
-                aliasId = aliasId,
-                includeArchived = includeArchived
-            });
-        }
-
         public async Task<(LeaderboardEntry, bool)> AddEntry(string internalName, float score, params (string, string)[] propTuples)
         {
             Talo.IdentityCheck();


### PR DESCRIPTION
**Deprecated API cleanup**
- Removed the `[Obsolete]` `GetEntries` overload that accepted raw parameters (`int page`, `int aliasId`, `bool includeArchived`), since the `GetEntriesOptions` object-based overload has been available as the replacement. Callers must now pass a `GetEntriesOptions` instance instead of spread arguments.