### PR TITLE
Replace ChannelStoragePropError with RejectedProp

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
@@ -87,7 +87,7 @@ namespace TaloGameServices
         public event Action<Channel> OnChannelDeleted;
         public event Action<Channel, string[]> OnChannelUpdated;
         public event Action<RejectedProp[]> OnChannelPropsRejected;
-        public event Action<Channel, ChannelStoragePropError[]> OnChannelStoragePropsFailedToSet;
+        public event Action<Channel, RejectedProp[]> OnChannelStoragePropsFailedToSet;
         public event Action<Channel, ChannelStorageProp[], ChannelStorageProp[]> OnChannelStoragePropsUpdated;
 
         private readonly ChannelStorageManager _storageManager = new ();

--- a/Assets/Talo Game Services/Talo/Runtime/Responses/ChannelStoragePropsSetResponse.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/Responses/ChannelStoragePropsSetResponse.cs
@@ -3,17 +3,9 @@ using System;
 namespace TaloGameServices
 {
     [Serializable]
-    public class ChannelStoragePropError
-    {
-        public string key;
-        public string error;
-        public string message;
-    }
-
-    [Serializable]
     public class ChannelStoragePropsSetResponse
     {
         public Channel channel;
-        public ChannelStoragePropError[] failedProps;
+        public RejectedProp[] failedProps;
     }
 }

--- a/Assets/Talo Game Services/Talo/Samples/ChannelStorageDemo/Scripts/ChannelStorageDemoUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/ChannelStorageDemo/Scripts/ChannelStorageDemoUIController.cs
@@ -139,7 +139,7 @@ namespace TaloGameServices.Sample.ChannelStorageDemo
             }
         }
 
-        private void OnChannelStoragePropsFailedToSet(Channel channel, ChannelStoragePropError[] errors)
+        private void OnChannelStoragePropsFailedToSet(Channel channel, RejectedProp[] errors)
         {
             foreach (var prop in errors)
             {


### PR DESCRIPTION
**Type consolidation**
- Removed the now-redundant `ChannelStoragePropError` class (which had identical fields `key`, `error`, `message` as `RejectedProp`)
- Replaced all `ChannelStoragePropError[]` references with the pre-existing `RejectedProp[]` in `ChannelsAPI.OnChannelStoragePropsFailedToSet`, the response DTO, and sample UI code
- Unifies failed-prop error reporting across channels so callers see a single type (`RejectedProp`) whether props are rejected during a set operation or via the existing `OnChannelPropsRejected` event