### PR TITLE
Return player alias from OnIdentified event

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
@@ -16,7 +16,7 @@ namespace TaloGameServices
             Update
         }
 
-        public event Action<Player> OnIdentified;
+        public event Action<PlayerAlias> OnIdentified;
         public event Action OnIdentificationStarted;
         public event Action OnIdentificationFailed;
         public event Action OnIdentityCleared;
@@ -43,10 +43,10 @@ namespace TaloGameServices
 
         public void InvokeIdentifiedEvent()
         {
-            OnIdentified?.Invoke(Talo.CurrentPlayer);
+            OnIdentified?.Invoke(Talo.CurrentAlias);
         }
 
-        private async Task<Player> HandleIdentifySuccess(PlayerAlias alias, string socketToken = "")
+        private async Task<PlayerAlias> HandleIdentifySuccess(PlayerAlias alias, string socketToken = "")
         {
             if (!Talo.IsOffline() && Talo.Socket.IsIdentified())
             {
@@ -61,10 +61,10 @@ namespace TaloGameServices
 
             InvokeIdentifiedEvent();
 
-            return alias.player;
+            return alias;
         }
 
-        public async Task<Player> Identify(string service, string identifier)
+        public async Task<PlayerAlias> Identify(string service, string identifier)
         {
             OnIdentificationStarted?.Invoke();
 
@@ -92,27 +92,24 @@ namespace TaloGameServices
             }
         }
 
-        public async Task<Player> IdentifySteam(string ticket, string identityClient = "")
+        public async Task<PlayerAlias> IdentifySteam(string ticket, string identityClient = "")
         {
             if (string.IsNullOrEmpty(identityClient))
             {
-                await Identify("steam", ticket);
+                return await Identify("steam", ticket);
             }
             else
             {
-                await Identify("steam", $"{identityClient}:{ticket}");
+                return await Identify("steam", $"{identityClient}:{ticket}");
             }
-
-            return Talo.CurrentPlayer;
         }
 
-        public async Task<Player> IdentifyGooglePlayGames(string authCode)
+        public async Task<PlayerAlias> IdentifyGooglePlayGames(string authCode)
         {
-            await Identify("google_play_games", authCode);
-            return Talo.CurrentPlayer;
+            return await Identify("google_play_games", authCode);
         }
 
-        public async Task<Player> IdentifyGameCenter(
+        public async Task<PlayerAlias> IdentifyGameCenter(
             string publicKeyUrl,
             byte[] signature,
             byte[] salt,
@@ -132,8 +129,7 @@ namespace TaloGameServices
 
             var identifier = Uri.EscapeDataString(JsonUtility.ToJson(payload));
 
-            await Identify("game_center", identifier);
-            return Talo.CurrentPlayer;
+            return await Identify("game_center", identifier);
         }
 
         protected override async Task ExecuteDebouncedOperation(DebouncedOperation operation)
@@ -203,7 +199,7 @@ namespace TaloGameServices
             return res.player;
         }
 
-        private async Task<Player> IdentifyOffline(string service, string identifier)
+        private async Task<PlayerAlias> IdentifyOffline(string service, string identifier)
         {
             PlayerAlias offlineAlias;
             try

--- a/Assets/Talo Game Services/Talo/Samples/AuthenticationDemo/Scripts/GameUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/AuthenticationDemo/Scripts/GameUIController.cs
@@ -19,9 +19,9 @@ namespace TaloGameServices.Sample.AuthenticationDemo
             Talo.Players.OnIdentified -= OnIdentified;
         }
 
-        private void OnIdentified(Player player)
+        private void OnIdentified(PlayerAlias alias)
         {
-            root.Q<Label>("title").text = $"Hi, {Talo.CurrentAlias.identifier}";
+            root.Q<Label>("title").text = $"Hi, {alias.identifier}";
         }
 
         private async void OnLogoutClick()

--- a/Assets/Talo Game Services/Talo/Samples/AuthenticationDemo/Scripts/GlobalUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/AuthenticationDemo/Scripts/GlobalUIController.cs
@@ -22,7 +22,7 @@ namespace TaloGameServices.Sample.AuthenticationDemo
             Talo.Players.OnIdentified -= OnIdentified;
         }
 
-        private void OnIdentified(Player player)
+        private void OnIdentified(PlayerAlias alias)
         {
             GoToGame();
         }

--- a/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Players/IdentifyPlayer.cs
+++ b/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Players/IdentifyPlayer.cs
@@ -38,12 +38,12 @@ namespace TaloGameServices.Sample.Playground
             }
         }
 
-        private void OnIdentified(Player player)
+        private void OnIdentified(PlayerAlias alias)
         {
             var panel = GameObject.Find("APIs");
             if (panel != null)
             {
-                ResponseMessage.SetText($"Identified ({Talo.CurrentAlias.displayName})!");
+                ResponseMessage.SetText($"Identified ({alias.displayName})!");
                 panel.GetComponent<Image>().color = new Color(120 / 255f, 230 / 255f, 160 / 255f);
             }
         }

--- a/Assets/Talo Game Services/Talo/Samples/SavesDemo/Scripts/GlobalUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/SavesDemo/Scripts/GlobalUIController.cs
@@ -16,7 +16,7 @@ namespace TaloGameServices.Sample.SavesDemo
 
             if (Talo.CurrentAlias != null)
             {
-                OnIdentified(Talo.CurrentPlayer);
+                OnIdentified(Talo.CurrentAlias);
             }
         }
 
@@ -32,7 +32,7 @@ namespace TaloGameServices.Sample.SavesDemo
             Talo.Saves.OnSaveChosen -= OnSaveChosen;
         }
 
-        private async void OnIdentified(Player player)
+        private async void OnIdentified(PlayerAlias alias)
         {
             await Talo.Saves.GetSaves();
             SetDocumentVisibility(loginUI, DisplayStyle.None);


### PR DESCRIPTION
**OnIdentified event signature**
- Changed `PlayersAPI.OnIdentified` from `Action<Player>` to `Action<PlayerAlias>`, so subscribers now receive the alias object directly instead of the full player object

**Identify method return types**
- `Identify`, `IdentifySteam`, `IdentifyGooglePlayGames`, `IdentifyGameCenter`, and `HandleIdentifySuccess` all return `Task<PlayerAlias>` instead of `Task<Player>`, eliminating the need for consumers to access `Talo.CurrentPlayer` after calling these methods

**Dead code elimination**
- Removed redundant `return Talo.CurrentPlayer` lines from `IdentifySteam`, `IdentifyGooglePlayGames`, and `IdentifyGameCenter` since the underlying `Identify()` call now returns the alias directly, making the API surface more consistent and predictable