### PR TITLE
Include error code in OnIdentificationFailed event

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/BaseAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/BaseAPI.cs
@@ -145,7 +145,14 @@ namespace TaloGameServices
                             return await Call(uri, method, content, headers, continuity);
                         }
 
-                        throw new PlayerAuthException(errorCode, new Exception(message));
+                        if (uri.AbsolutePath.Contains("/v1/players/auth/"))
+                        {
+                            throw new PlayerAuthException(errorCode, new Exception(message));
+                        }
+                        else
+                        {
+                            throw new RequestException(www.responseCode, new Exception(message), www.downloadHandler.text);
+                        }
                     }
                 }
             }

--- a/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
@@ -18,7 +18,7 @@ namespace TaloGameServices
 
         public event Action<PlayerAlias> OnIdentified;
         public event Action OnIdentificationStarted;
-        public event Action OnIdentificationFailed;
+        public event Action<IdentifyException> OnIdentificationFailed;
         public event Action OnIdentityCleared;
         public event Action<RejectedProp[]> OnPropsRejected;
 
@@ -75,21 +75,21 @@ namespace TaloGameServices
 
             var uri = new Uri($"{baseUrl}/identify?service={service}&identifier={identifier}");
 
+            PlayersIdentifyResponse res;
             try
             {
                 var json = await Call(uri, "GET");
-
-                var res = JsonUtility.FromJson<PlayersIdentifyResponse>(json);
-                var alias = res.alias;
-                alias.WriteOfflineAlias();
-                return await HandleIdentifySuccess(alias, res.socketToken);
+                res = JsonUtility.FromJson<PlayersIdentifyResponse>(json);
             }
-            catch
+            catch (Exception ex)
             {
                 await Talo.PlayerAuth.SessionManager.ClearSession();
-                OnIdentificationFailed?.Invoke();
+                OnIdentificationFailed?.Invoke(IdentifyException.FromException(ex));
                 throw;
             }
+
+            res.alias.WriteOfflineAlias();
+            return await HandleIdentifySuccess(res.alias, res.socketToken);
         }
 
         public async Task<PlayerAlias> IdentifySteam(string ticket, string identityClient = "")
@@ -209,7 +209,7 @@ namespace TaloGameServices
             catch
             {
                 PlayerAlias.DeleteOfflineAlias();
-                OnIdentificationFailed?.Invoke();
+                OnIdentificationFailed?.Invoke(new IdentifyException());
                 throw new Exception("Failed to parse offline player alias");
             }
 
@@ -218,7 +218,7 @@ namespace TaloGameServices
                 return await HandleIdentifySuccess(offlineAlias);
             }
 
-            OnIdentificationFailed?.Invoke();
+            OnIdentificationFailed?.Invoke(new IdentifyException());
             throw new Exception("No offline player alias found");
         }
 

--- a/Assets/Talo Game Services/Talo/Runtime/Utils/IdentifyException.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/Utils/IdentifyException.cs
@@ -1,0 +1,62 @@
+using System;
+using UnityEngine;
+
+namespace TaloGameServices
+{
+    public enum IdentifyErrorCode
+    {
+        UNKNOWN_ERROR,
+        IDENTIFIER_PROFANITY,
+        IDENTIFIER_TAKEN
+    }
+
+    public class IdentifyException : Exception
+    {
+        public IdentifyErrorCode ErrorCode { get; }
+
+        public IdentifyException(IdentifyErrorCode code = IdentifyErrorCode.UNKNOWN_ERROR)
+            : base(code.ToString())
+        {
+            ErrorCode = code;
+        }
+
+        public IdentifyException(IdentifyErrorCode code, Exception inner)
+            : base(code.ToString(), inner)
+        {
+            ErrorCode = code;
+        }
+
+        public static IdentifyException FromException(Exception ex)
+        {
+            if (ex is RequestException re && !string.IsNullOrEmpty(re.responseBody))
+            {
+                return FromResponse(re.responseBody);
+            }
+
+            return new IdentifyException();
+        }
+
+        private static IdentifyException FromResponse(string body)
+        {
+            if (string.IsNullOrEmpty(body))
+            {
+                return new IdentifyException();
+            }
+
+            try
+            {
+                var parsed = JsonUtility.FromJson<ErrorResponse>(body);
+                if (parsed != null && !string.IsNullOrEmpty(parsed.errorCode) &&
+                    Enum.TryParse(parsed.errorCode, out IdentifyErrorCode code))
+                {
+                    return new IdentifyException(code);
+                }
+            }
+            catch
+            {
+            }
+
+            return new IdentifyException();
+        }
+    }
+}

--- a/Assets/Talo Game Services/Talo/Runtime/Utils/IdentifyException.cs.meta
+++ b/Assets/Talo Game Services/Talo/Runtime/Utils/IdentifyException.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6ca927edafd34429a5ae1699cca53b5


### PR DESCRIPTION
**Exception type separation**
- Non-auth API errors now throw `RequestException` instead of `PlayerAuthException`, so auth-specific errors are only raised on auth endpoints

**Granular identification errors**
- New `IdentifyException` with enum codes `IDENTIFIER_PROFANITY` and `IDENTIFIER_TAKEN` lets game code react to specific failure reasons instead of catching a generic exception

**Identification failure event enriched**
- `OnIdentificationFailed` now passes `IdentifyException` to subscribers, allowing callers to inspect error details (e.g. profanity/content filtering) rather than getting a bare notification