### PR TITLE
Add FlushUpdates and events for players/saves debounced updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,18 +45,22 @@ The SDK supports offline operation via `TaloSettings.offlineMode`. When offline,
 Events are batched and flushed on application quit/pause/focus loss. On WebGL, events flush every `webGLEventFlushRate` seconds (default 30s) due to platform limitations.
 
 ### Debouncing
-Player updates and save updates are debounced to prevent excessive API calls during rapid property changes. APIs that need debouncing inherit from `DebouncedAPI<TOperation>` (a generic base class) and define a `DebouncedOperation` enum for type-safe operation keys. The base class uses a dictionary to track multiple debounced operations independently.
+Player updates and save updates are debounced to prevent excessive API calls during rapid property changes. APIs that need debouncing inherit from `DebouncedAPI<TOperation, TReturnData, TUpdateResult>` and define a `DebouncedOperation` enum for type-safe operation keys. The base class uses a dictionary to track multiple debounced operations independently.
 
 The debounce is **leading and trailing**: the first call fires immediately (leading), and if further calls arrive during the debounce window they are coalesced into a single trailing call executed after the window closes. The window is defined by `debounceTimerSeconds` (default: 1s) and resets on each subsequent call.
 
 To add debouncing to an API:
 1. Define a public `enum DebouncedOperation` with your debounced operations
-2. Inherit from `DebouncedAPI<YourAPI.DebouncedOperation>`
+2. Inherit from `DebouncedAPI<YourAPI.DebouncedOperation, TReturnData, TUpdateResult>`
 3. Call `Debounce(DebouncedOperation.YourOperation)` to queue an operation
 4. Implement `ExecuteDebouncedOperation(DebouncedOperation operation)` with a switch statement
 5. The base class's `ProcessPendingUpdates()` is called by `TaloManager.Update()` every frame
 
-Example: `PlayersAPI` defines `enum DebouncedOperation { Update }` and inherits from `DebouncedAPI<PlayersAPI.DebouncedOperation>`. When `Player.SetProp()` is called, it calls `Debounce(DebouncedOperation.Update)`. The first call fires immediately; subsequent calls within the debounce window result in a single trailing API call at the end of the window.
+Example: `PlayersAPI` defines `enum DebouncedOperation { Update }` and inherits from `DebouncedAPI<PlayersAPI.DebouncedOperation, RejectedProp[], PlayersAPI.PlayerUpdateResult>`. When `Player.SetProp()` is called, it calls `Debounce(DebouncedOperation.Update)`. The first call fires immediately; subsequent calls within the debounce window result in a single trailing API call at the end of the window.
+
+#### Debounced update completion signals
+
+`Player.SetProp(...)` returns `Task<PlayerUpdateResult>`, `Talo.Saves.UpdateCurrentSave()` returns `Task<SaveUpdateResult>`. All callers in the same debounce window share the same settle result. `FlushUpdates()` returns `FlushResult` (`NothingPending`, `Success`, `Failure`). `OnPlayerUpdated(bool)` / `OnSaveUpdated(bool, GameSave)` fire after each settle. `TaloManager.OnApplicationQuit()` flushes pending updates automatically.
 
 ## Key Configuration
 

--- a/Assets/Talo Game Services/Talo/Runtime/APIs/DebouncedAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/DebouncedAPI.cs
@@ -5,7 +5,19 @@ using UnityEngine;
 
 namespace TaloGameServices
 {
-    public abstract class DebouncedAPI<TOperation> : BaseAPI where TOperation : Enum
+    public abstract class DebouncedAPIBase : BaseAPI
+    {
+        public enum FlushResult
+        {
+            NothingPending,
+            Success,
+            Failure
+        }
+
+        protected DebouncedAPIBase(string service) : base(service) { }
+    }
+
+    public abstract class DebouncedAPI<TOperation, TReturnData, TUpdateResult> : DebouncedAPIBase where TOperation : Enum
     {
         private class DebouncedOperation
         {
@@ -13,9 +25,13 @@ namespace TaloGameServices
             public bool windowOpen;
             public bool hasTrailingCallQueued;
             public bool isExecuting;
+            public Task<TReturnData> currentTask;
+            public List<TaskCompletionSource<TUpdateResult>> pendingTasks = new();
         }
 
         private readonly Dictionary<TOperation, DebouncedOperation> operations = new();
+
+        protected event Action<bool, TReturnData> OnOperationSettled;
 
         protected DebouncedAPI(string service) : base(service) { }
 
@@ -25,7 +41,7 @@ namespace TaloGameServices
             op.windowEndTime = Time.realtimeSinceStartup + Talo.Settings.debounceTimerSeconds;
         }
 
-        protected void Debounce(TOperation operation)
+        protected Task<TUpdateResult> Debounce(TOperation operation)
         {
             if (!operations.ContainsKey(operation))
             {
@@ -36,25 +52,60 @@ namespace TaloGameServices
 
             if (!op.windowOpen && !op.isExecuting)
             {
-                // leading call: fire immediately and open the debounce window
                 op.hasTrailingCallQueued = false;
                 op.isExecuting = true;
                 OpenWindow(op);
 
-                ExecuteDebouncedOperation(operation).ContinueWith((t) => {
-                    op.isExecuting = false;
-                    if (t.IsFaulted)
-                    {
-                        Debug.LogError(t.Exception);
-                    }
-                }, TaskScheduler.FromCurrentSynchronizationContext());
+                var pending = new List<TaskCompletionSource<TUpdateResult>>(op.pendingTasks);
+                op.pendingTasks.Clear();
+
+                return SettleLeading(operation, op, pending);
             }
             else
             {
-                // window open or request in-flight: queue a trailing call and extend the window
+                var tcs = new TaskCompletionSource<TUpdateResult>();
+                op.pendingTasks.Add(tcs);
                 op.hasTrailingCallQueued = true;
                 OpenWindow(op);
+                return tcs.Task;
             }
+        }
+
+        private async Task<TUpdateResult> SettleLeading(TOperation operation, DebouncedOperation op, List<TaskCompletionSource<TUpdateResult>> pending)
+        {
+            (_, var result) = await RunAndSettle(operation, op, pending);
+            return result;
+        }
+
+        private async Task<(bool success, TUpdateResult result)> RunAndSettle(TOperation operation, DebouncedOperation op, List<TaskCompletionSource<TUpdateResult>> pending)
+        {
+            op.currentTask = ExecuteDebouncedOperation(operation);
+
+            bool success;
+            TReturnData returnData;
+            try
+            {
+                returnData = await op.currentTask;
+                success = true;
+            }
+            catch (Exception)
+            {
+                returnData = default;
+                success = false;
+            }
+            finally
+            {
+                op.isExecuting = false;
+            }
+
+            OnOperationSettled?.Invoke(success, returnData);
+
+            var result = BuildResult(success, returnData);
+            foreach (var tcs in pending)
+            {
+                tcs.SetResult(result);
+            }
+            return (success, result);
         }
 
         public async Task ProcessPendingUpdates()
@@ -93,18 +144,54 @@ namespace TaloGameServices
                 var op = operations[key];
                 op.hasTrailingCallQueued = false;
                 op.isExecuting = true;
-                try
-                {
-                    await ExecuteDebouncedOperation(key);
-                }
-                finally
-                {
-                    op.isExecuting = false;
-                    op.windowOpen = false;
-                }
+
+                var pending = new List<TaskCompletionSource<TUpdateResult>>(op.pendingTasks);
+                op.pendingTasks.Clear();
+
+                await RunAndSettle(key, op, pending);
             }
         }
 
-        protected abstract Task ExecuteDebouncedOperation(TOperation operation);
+        public async Task<FlushResult> FlushUpdates()
+        {
+            var result = FlushResult.NothingPending;
+
+            var keys = new List<TOperation>(operations.Keys);
+            foreach (var key in keys)
+            {
+                var op = operations[key];
+
+                if (op.isExecuting)
+                {
+                    await op.currentTask;
+                }
+
+                while (op.hasTrailingCallQueued)
+                {
+                    op.hasTrailingCallQueued = false;
+                    op.isExecuting = true;
+
+                    var pending = new List<TaskCompletionSource<TUpdateResult>>(op.pendingTasks);
+                    op.pendingTasks.Clear();
+
+                    var (settleSuccess, _) = await RunAndSettle(key, op, pending);
+                    if (settleSuccess)
+                    {
+                        if (result == FlushResult.NothingPending) result = FlushResult.Success;
+                    }
+                    else
+                    {
+                        result = FlushResult.Failure;
+                    }
+                }
+
+                op.windowOpen = false;
+            }
+
+            return result;
+        }
+
+        protected abstract Task<TReturnData> ExecuteDebouncedOperation(TOperation operation);
+        protected abstract TUpdateResult BuildResult(bool success, TReturnData returnData);
     }
 }

--- a/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
@@ -9,7 +9,7 @@ namespace TaloGameServices
         public string postMergeIdentityService = "";
     }
 
-    public class PlayersAPI : DebouncedAPI<PlayersAPI.DebouncedOperation>
+    public class PlayersAPI : DebouncedAPI<PlayersAPI.DebouncedOperation, RejectedProp[], PlayersAPI.PlayerUpdateResult>
     {
         public enum DebouncedOperation
         {
@@ -21,10 +21,12 @@ namespace TaloGameServices
         public event Action<IdentifyException> OnIdentificationFailed;
         public event Action OnIdentityCleared;
         public event Action<RejectedProp[]> OnPropsRejected;
+        public event Action<bool> OnPlayerUpdated;
 
         public PlayersAPI() : base("v1/players")
         {
             Talo.OnConnectionRestored += OnConnectionRestored;
+            OnOperationSettled += (success, _) => OnPlayerUpdated?.Invoke(success);
         }
 
         private async void OnConnectionRestored()
@@ -132,22 +134,36 @@ namespace TaloGameServices
             return await Identify("game_center", identifier);
         }
 
-        protected override async Task ExecuteDebouncedOperation(DebouncedOperation operation)
+        protected override async Task<RejectedProp[]> ExecuteDebouncedOperation(DebouncedOperation operation)
         {
-            switch (operation)
+            return operation switch
             {
-                case DebouncedOperation.Update:
-                    await Update();
-                    break;
-            }
+                DebouncedOperation.Update => await RunUpdate(),
+                _ => null,
+            };
         }
 
-        public void DebounceUpdate()
+        protected override PlayerUpdateResult BuildResult(bool success, RejectedProp[] updateData)
         {
-            Debounce(DebouncedOperation.Update);
+            if (!success)
+            {
+                return new PlayerUpdateResult(false);
+            }
+            return new PlayerUpdateResult(true, updateData);
+        }
+
+        public Task<PlayerUpdateResult> DebounceUpdate()
+        {
+            return Debounce(DebouncedOperation.Update);
         }
 
         public async Task<Player> Update()
+        {
+            await RunUpdate();
+            return Talo.CurrentPlayer;
+        }
+
+        private async Task<RejectedProp[]> RunUpdate()
         {
             Talo.IdentityCheck();
 
@@ -164,7 +180,7 @@ namespace TaloGameServices
                 OnPropsRejected?.Invoke(res.rejectedProps);
             }
 
-            return Talo.CurrentPlayer;
+            return res.rejectedProps ?? Array.Empty<RejectedProp>();
         }
 
         public async Task<Player> Merge(string playerId1, string playerId2, MergeOptions options = null)
@@ -256,6 +272,18 @@ namespace TaloGameServices
             {
                 Debug.LogWarning($"Failed to create socket token: {ex.Message}");
                 return "";
+            }
+        }
+
+        public class PlayerUpdateResult
+        {
+            public bool Success { get; }
+            public RejectedProp[] RejectedProps { get; }
+
+            public PlayerUpdateResult(bool success, RejectedProp[] rejectedProps = null)
+            {
+                Success = success;
+                RejectedProps = rejectedProps ?? Array.Empty<RejectedProp>();
             }
         }
     }

--- a/Assets/Talo Game Services/Talo/Runtime/APIs/SavesAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/SavesAPI.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace TaloGameServices
 {
-    public class SavesAPI : DebouncedAPI<SavesAPI.DebouncedOperation>
+    public class SavesAPI : DebouncedAPI<SavesAPI.DebouncedOperation, GameSave, SavesAPI.SaveUpdateResult>
     {
         public enum DebouncedOperation
         {
@@ -21,6 +21,7 @@ namespace TaloGameServices
 
         public event Action<GameSave> OnSaveChosen;
         public event Action<GameSave> OnSaveUnloaded;
+        public event Action<bool, GameSave> OnSaveUpdated;
 
         public GameSave[] All
         {
@@ -38,7 +39,11 @@ namespace TaloGameServices
         }
 
         public SavesAPI() : base("v1/game-saves")
-        { }
+        {
+            OnOperationSettled += (success, save) => {
+                OnSaveUpdated?.Invoke(success, success ? save : null);
+            };
+        }
 
         internal void Setup()
         {
@@ -191,7 +196,7 @@ namespace TaloGameServices
             return savesManager.CreateSave(save);
         }
 
-        protected override async Task ExecuteDebouncedOperation(DebouncedOperation operation)
+        protected override async Task<GameSave> ExecuteDebouncedOperation(DebouncedOperation operation)
         {
             switch (operation)
             {
@@ -199,18 +204,24 @@ namespace TaloGameServices
                     var currentSave = savesManager.CurrentSave;
                     if (currentSave != null)
                     {
-                        await UpdateSave(currentSave.id);
+                        return await UpdateSave(currentSave.id);
                     }
                     break;
             }
+            return null;
         }
 
-        public void DebounceUpdate()
+        protected override SaveUpdateResult BuildResult(bool success, GameSave updateData)
         {
-            Debounce(DebouncedOperation.Update);
+            return new SaveUpdateResult(success, success ? updateData : null);
         }
 
-        public async Task<GameSave> UpdateCurrentSave(string newName = "")
+        public Task<SaveUpdateResult> DebounceUpdate()
+        {
+            return Debounce(DebouncedOperation.Update);
+        }
+
+        public async Task<SaveUpdateResult> UpdateCurrentSave(string newName = "")
         {
             var currentSave = savesManager.CurrentSave;
             if (currentSave == null)
@@ -221,13 +232,16 @@ namespace TaloGameServices
             // if the save is being renamed, sync it immediately
             if (!string.IsNullOrEmpty(newName))
             {
-                return await UpdateSave(currentSave.id, newName);
+                var save = await UpdateSave(currentSave.id, newName);
+                var success = save != null;
+                var result = new SaveUpdateResult(success, save);
+                OnSaveUpdated?.Invoke(success, save);
+                return result;
             }
 
             // else, update the save locally and queue it for syncing
             currentSave.content = contentManager.Content;
-            DebounceUpdate();
-            return currentSave;
+            return await DebounceUpdate();
         }
 
         public async Task<GameSave> UpdateSave(int saveId, string newName = "")
@@ -238,7 +252,10 @@ namespace TaloGameServices
 
             if (Talo.IsOffline())
             {
-                if (!string.IsNullOrEmpty(newName)) save.name = newName;
+                if (!string.IsNullOrEmpty(newName))
+                {
+                    save.name = newName;
+                }
                 save.content = saveContent;
                 save.updatedAt = DateTime.UtcNow.ToString("O");
             }
@@ -254,7 +271,6 @@ namespace TaloGameServices
                 });
 
                 var json = await Call(uri, "PATCH", content);
-
                 var res = JsonUtility.FromJson<SavesPostResponse>(json);
                 save = res.save;
             }
@@ -292,6 +308,18 @@ namespace TaloGameServices
             }
 
             savesManager.DeleteSave(saveId, unloadIfCurrentSave);
+        }
+
+        public class SaveUpdateResult
+        {
+            public bool Success { get; }
+            public GameSave Save { get; }
+
+            public SaveUpdateResult(bool success, GameSave save = null)
+            {
+                Success = success;
+                Save = save;
+            }
         }
     }
 }

--- a/Assets/Talo Game Services/Talo/Runtime/Entities/Player.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/Entities/Player.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace TaloGameServices
 {
@@ -18,64 +19,70 @@ namespace TaloGameServices
             return JsonUtility.ToJson(this);
         }
 
-        public void SetProp(string key, string value, bool update = true)
+        public Task<PlayersAPI.PlayerUpdateResult> SetProp(string key, string value, bool update = true)
         {
             base.SetProp(key, value);
 
             if (update)
             {
-                Talo.Players.DebounceUpdate();
+                return Talo.Players.DebounceUpdate();
             }
+            return Task.FromResult(new PlayersAPI.PlayerUpdateResult(true));
         }
 
-        public void DeleteProp(string key, bool update = true)
+        public Task<PlayersAPI.PlayerUpdateResult> DeleteProp(string key, bool update = true)
         {
             base.DeleteProp(key);
 
             if (update)
             {
-                Talo.Players.DebounceUpdate();
+                return Talo.Players.DebounceUpdate();
             }
+            return Task.FromResult(new PlayersAPI.PlayerUpdateResult(true));
         }
 
-        public void SetPropArray(string key, IEnumerable<string> values, bool update = true)
+        public Task<PlayersAPI.PlayerUpdateResult> SetPropArray(string key, IEnumerable<string> values, bool update = true)
         {
             base.SetPropArray(key, values);
 
             if (update)
             {
-                Talo.Players.DebounceUpdate();
+                return Talo.Players.DebounceUpdate();
             }
+            return Task.FromResult(new PlayersAPI.PlayerUpdateResult(true));
         }
 
-        public void DeletePropArray(string key, bool update = true)
+        public Task<PlayersAPI.PlayerUpdateResult> DeletePropArray(string key, bool update = true)
         {
             base.DeletePropArray(key);
 
             if (update)
             {
-                Talo.Players.DebounceUpdate();
+                return Talo.Players.DebounceUpdate();
             }
+            return Task.FromResult(new PlayersAPI.PlayerUpdateResult(true));
         }
 
-        public void InsertIntoPropArray(string key, string value, bool update = true)
+        public Task<PlayersAPI.PlayerUpdateResult> InsertIntoPropArray(string key, string value, bool update = true)
         {
             base.InsertIntoPropArray(key, value);
 
             if (update)
             {
-                Talo.Players.DebounceUpdate();
+                return Talo.Players.DebounceUpdate();
             }
+            return Task.FromResult(new PlayersAPI.PlayerUpdateResult(true));
         }
 
-        public void RemoveFromPropArray(string key, string value, bool update = true)
+        public Task<PlayersAPI.PlayerUpdateResult> RemoveFromPropArray(string key, string value, bool update = true)
         {
             base.RemoveFromPropArray(key, value);
 
             if (update)
             {
-                Talo.Players.DebounceUpdate();
+                return Talo.Players.DebounceUpdate();
             }
+            return Task.FromResult(new PlayersAPI.PlayerUpdateResult(true));
         }
 
         public bool IsInGroupID(string groupId)

--- a/Assets/Talo Game Services/Talo/Runtime/TaloManager.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/TaloManager.cs
@@ -37,9 +37,24 @@ namespace TaloGameServices
             Talo.Events.OnFlushed -= ResetFlushTimer;
         }
 
-        private void OnApplicationQuit()
+        private async void OnApplicationQuit()
         {
-            DoFlush();
+            try
+            {
+                if (Talo.HasIdentity())
+                {
+                    await Talo.Events.Flush();
+                    await Talo.Players.FlushUpdates();
+                    if (Talo.Saves.Current != null)
+                    {
+                        await Talo.Saves.FlushUpdates();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to flush on quit: {ex}");
+            }
         }
 
         private void OnApplicationFocus(bool hasFocus)

--- a/Assets/Talo Game Services/Talo/Runtime/Utils/RequestMock.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/Utils/RequestMock.cs
@@ -13,8 +13,8 @@ namespace TaloGameServices
             public long status;
         }
 
-        private static List<RequestHandler> _permanentHandlers = new List<RequestHandler>();
-        private static List<RequestHandler> _oneTimeHandlers = new List<RequestHandler>();
+        private static readonly List<RequestHandler> _permanentHandlers = new();
+        private static readonly List<RequestHandler> _oneTimeHandlers = new();
         private static bool _offline;
 
         public static bool Offline

--- a/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Players/SetProp.cs
+++ b/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Players/SetProp.cs
@@ -7,22 +7,12 @@ namespace TaloGameServices.Sample.Playground
     {
         public string key, value;
 
-        private void OnEnable()
-        {
-            Talo.Players.OnPropsRejected += OnPropsRejected;
-        }
-
-        private void OnDisable()
-        {
-            Talo.Players.OnPropsRejected -= OnPropsRejected;
-        }
-
         public void OnButtonClick()
         {
             UpdateProp();
         }
 
-        private void UpdateProp()
+        private async void UpdateProp()
         {
             if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
             {
@@ -32,20 +22,21 @@ namespace TaloGameServices.Sample.Playground
 
             try
             {
-                Talo.CurrentPlayer.SetProp(key, value);
-                ResponseMessage.SetText($"{key} set to {value}");
+                var result = await Talo.CurrentPlayer.SetProp(key, value);
+
+                if (result.RejectedProps.Length > 0)
+                {
+                    var reasons = string.Join(", ", Array.ConvertAll(result.RejectedProps, (rp) => $"[{rp.key}] {rp.message}"));
+                    ResponseMessage.SetText($"Rejected props: {reasons}");
+                    return;
+                }
+
+                ResponseMessage.SetText($"{key} saved successfully");
             }
-            catch (System.Exception ex)
+            catch (Exception ex)
             {
                 ResponseMessage.SetText(ex.Message);
-                throw;
             }
-        }
-
-        private void OnPropsRejected(RejectedProp[] rejectedProps)
-        {
-            var reasons = string.Join(", ", Array.ConvertAll(rejectedProps, (rp) => $"[{rp.key}] {rp.message}"));
-            ResponseMessage.SetText($"Rejected props: {reasons}");
         }
     }
 }

--- a/Assets/Talo Game Services/Talo/Samples/SavesDemo/Scripts/GameUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/SavesDemo/Scripts/GameUIController.cs
@@ -29,8 +29,6 @@ namespace TaloGameServices.Sample.SavesDemo
             updateSaveButton.clicked += async () =>
             {
                 await Talo.Saves.UpdateCurrentSave();
-                updateSaveButton.text = "Saved!";
-                Invoke("ResetUpdateSaveButtonText", 1f);
             };
 
             root.Q<Button>("back-btn").clicked += () =>
@@ -40,6 +38,22 @@ namespace TaloGameServices.Sample.SavesDemo
             };
 
             SetupLevelButtons();
+        }
+
+        private void OnEnable()
+        {
+            Talo.Saves.OnSaveUpdated += OnSaveUpdated;
+        }
+
+        private void OnDisable()
+        {
+            Talo.Saves.OnSaveUpdated -= OnSaveUpdated;
+        }
+
+        private void OnSaveUpdated(bool success, GameSave save)
+        {
+            updateSaveButton.text = success ? "Saved!" : "Save failed";
+            Invoke(nameof(ResetUpdateSaveButtonText), 1f);
         }
 
         private void SetupLevelButtons()

--- a/Assets/Talo Game Services/Talo/Tests/PlayersAPI/PlayerUpdatedEventTest.cs
+++ b/Assets/Talo Game Services/Talo/Tests/PlayersAPI/PlayerUpdatedEventTest.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TaloGameServices.Test
+{
+    internal class PlayerUpdateEventMock
+    {
+        public int updatedCount = 0;
+        public bool lastSuccess = false;
+
+        public void OnUpdated(bool success)
+        {
+            updatedCount++;
+            lastSuccess = success;
+        }
+    }
+
+    internal class PlayerUpdatedEventTest
+    {
+        private PlayersAPI _originalPlayersApi;
+        private PlayerUpdateEventMock _mock;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            var tm = new GameObject().AddComponent<TaloManager>();
+            tm.settings = ScriptableObject.CreateInstance<TaloSettings>();
+            tm.settings.autoConnectSocket = false;
+            tm.settings.debounceTimerSeconds = 0.1f;
+
+            Talo.CurrentAlias = new PlayerAlias() {
+                player = new Player() {
+                    id = "uuid",
+                    props = new[] { new Prop(("k1", "v1")) }
+                }
+            };
+
+            _originalPlayersApi = Talo.Players;
+        }
+
+        [SetUp]
+        public void PerTestSetUp()
+        {
+            _mock = new PlayerUpdateEventMock();
+            Talo._players = new PlayersAPI();
+            RequestMock.Reset();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Talo._players = _originalPlayersApi;
+            RequestMock.Reset();
+        }
+
+        [UnityTest]
+        public IEnumerator LeadingCall_FiresOnPlayerUpdated()
+        {
+            Talo.Players.OnPlayerUpdated += _mock.OnUpdated;
+
+            var uri = new Uri($"{Talo.Settings.apiUrl}/v1/players/uuid");
+            RequestMock.ReplyOnce(uri, "PATCH", JsonUtility.ToJson(new PlayersUpdateResponse
+            {
+                player = new Player { id = "uuid" }
+            }));
+
+            Talo.CurrentPlayer.SetProp("k1", "v1-updated");
+
+            Assert.AreEqual(1, _mock.updatedCount);
+            Assert.IsTrue(_mock.lastSuccess);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator LeadingAndTrailing_FireOnPlayerUpdatedTwice()
+        {
+            Talo.Players.OnPlayerUpdated += _mock.OnUpdated;
+
+            var uri = new Uri($"{Talo.Settings.apiUrl}/v1/players/uuid");
+            RequestMock.Reply(uri, "PATCH", JsonUtility.ToJson(new PlayersUpdateResponse
+            {
+                player = new Player { id = "uuid" }
+            }));
+
+            Talo.CurrentPlayer.SetProp("k1", "v1-updated");
+            Talo.CurrentPlayer.SetProp("k2", "v2");
+
+            Assert.AreEqual(1, _mock.updatedCount);
+
+            var result = Talo.Players.FlushUpdates().GetAwaiter().GetResult();
+            Assert.AreEqual(DebouncedAPIBase.FlushResult.Success, result);
+            Assert.AreEqual(2, _mock.updatedCount);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator PropRejection_BothOnPropsRejectedAndOnPlayerUpdatedFire()
+        {
+            int rejectedCount = 0;
+            Talo.Players.OnPlayerUpdated += _mock.OnUpdated;
+            Talo.Players.OnPropsRejected += _ =>
+            {
+                rejectedCount++;
+            };
+
+            var uri = new Uri($"{Talo.Settings.apiUrl}/v1/players/uuid");
+            RequestMock.ReplyOnce(uri, "PATCH", JsonUtility.ToJson(new PlayersUpdateResponse
+            {
+                player = new Player { id = "uuid" },
+                rejectedProps = new[] { new RejectedProp { key = "k1", error = "PROP_VALUE_TOO_LONG", message = "too long" } }
+            }));
+
+            Talo.CurrentPlayer.SetProp("k1", "v1-updated");
+
+            Assert.AreEqual(1, rejectedCount);
+            Assert.AreEqual(1, _mock.updatedCount);
+            Assert.IsTrue(_mock.lastSuccess);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator HttpError_FiresOnPlayerUpdatedWithFalse()
+        {
+            Talo.Players.OnPlayerUpdated += _mock.OnUpdated;
+
+            // no mock for update means the leading call's Debounce() fails
+
+            Talo.CurrentPlayer.SetProp("k1", "v1-updated");
+
+            Assert.AreEqual(1, _mock.updatedCount);
+            Assert.IsFalse(_mock.lastSuccess);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TrailingCall_FailsOnHttpError_ReturnsFlushResultFailure()
+        {
+            Talo.Players.OnPlayerUpdated += _mock.OnUpdated;
+
+            var uri = new Uri($"{Talo.Settings.apiUrl}/v1/players/uuid");
+            RequestMock.ReplyOnce(uri, "PATCH", JsonUtility.ToJson(new PlayersUpdateResponse
+            {
+                player = new Player { id = "uuid" }
+            }));
+
+            Talo.CurrentPlayer.SetProp("k1", "v1-updated");
+            Talo.CurrentPlayer.SetProp("k2", "v2");
+
+            Assert.AreEqual(1, _mock.updatedCount);
+            Assert.IsTrue(_mock.lastSuccess);
+
+            // trailing call has no mock so flush returns Failure (not throw)
+            var flushResult = Talo.Players.FlushUpdates().GetAwaiter().GetResult();
+            Assert.AreEqual(DebouncedAPIBase.FlushResult.Failure, flushResult);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator FlushUpdates_NoPending_ReturnsNothingPending()
+        {
+            var result = Talo.Players.FlushUpdates().GetAwaiter().GetResult();
+            Assert.AreEqual(DebouncedAPIBase.FlushResult.NothingPending, result);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator FlushUpdates_WithTrailingQueued_ReturnsSuccessAndFiresEvent()
+        {
+            Talo.Players.OnPlayerUpdated += _mock.OnUpdated;
+
+            var uri = new Uri($"{Talo.Settings.apiUrl}/v1/players/uuid");
+            RequestMock.Reply(uri, "PATCH", JsonUtility.ToJson(new PlayersUpdateResponse
+            {
+                player = new Player { id = "uuid" }
+            }));
+
+            Talo.CurrentPlayer.SetProp("k1", "v1-updated");
+            Talo.CurrentPlayer.SetProp("k2", "v2");
+
+            Assert.AreEqual(1, _mock.updatedCount);
+
+            var result = Talo.Players.FlushUpdates().GetAwaiter().GetResult();
+            Assert.AreEqual(DebouncedAPIBase.FlushResult.Success, result);
+            Assert.AreEqual(2, _mock.updatedCount);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator SetProp_ReturnsResultInline()
+        {
+            var uri = new Uri($"{Talo.Settings.apiUrl}/v1/players/uuid");
+            RequestMock.ReplyOnce(uri, "PATCH", JsonUtility.ToJson(new PlayersUpdateResponse
+            {
+                player = new Player { id = "uuid" }
+            }));
+
+            var result = Talo.CurrentPlayer.SetProp("k1", "v1-updated").GetAwaiter().GetResult();
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.RejectedProps.Length);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator SetProp_LocalOnly_ReturnsImmediateSuccess()
+        {
+            var result = Talo.CurrentPlayer.SetProp("k1", "v1-local", false).GetAwaiter().GetResult();
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(0, result.RejectedProps.Length);
+
+            yield return null;
+        }
+    }
+}

--- a/Assets/Talo Game Services/Talo/Tests/PlayersAPI/PlayerUpdatedEventTest.cs.meta
+++ b/Assets/Talo Game Services/Talo/Tests/PlayersAPI/PlayerUpdatedEventTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9466b9f624c1431ea743ce20a979ead5

--- a/Assets/Talo Game Services/Talo/Tests/SavesAPI/SaveUpdatedEventTest.cs
+++ b/Assets/Talo Game Services/Talo/Tests/SavesAPI/SaveUpdatedEventTest.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace TaloGameServices.Test
+{
+    internal class SaveUpdateEventMock
+    {
+        public int updatedCount = 0;
+        public bool lastSuccess = false;
+        public GameSave lastSave = null;
+
+        public void OnUpdated(bool success, GameSave save)
+        {
+            updatedCount++;
+            lastSuccess = success;
+            lastSave = save;
+        }
+    }
+
+    internal class SaveUpdatedEventTest
+    {
+        private SavesAPI _originalSavesApi;
+        private SaveUpdateEventMock _mock;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            var tm = new GameObject().AddComponent<TaloManager>();
+            tm.settings = ScriptableObject.CreateInstance<TaloSettings>();
+            tm.settings.autoConnectSocket = false;
+            tm.settings.debounceTimerSeconds = 0.1f;
+
+            Talo.CurrentAlias = new PlayerAlias() {
+                player = new Player() {
+                    id = "uuid"
+                }
+            };
+
+            _originalSavesApi = Talo.Saves;
+        }
+
+        [SetUp]
+        public void PerTestSetUp()
+        {
+            _mock = new SaveUpdateEventMock();
+            RequestMock.Reset();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Talo._saves = _originalSavesApi;
+            RequestMock.Reset();
+        }
+
+        private SavesAPI BuildApiWithChosenSave(int saveId, string name)
+        {
+            var api = new SavesAPI();
+            Talo._saves = api;
+            api.Setup();
+
+            var save = new GameSave { id = saveId, name = name };
+            api.savesManager._allSaves.Add(save);
+            api.savesManager.SetChosenSave(save, false);
+
+            return api;
+        }
+
+        private static string PatchedSaveJson()
+        {
+            return JsonUtility.ToJson(new SavesPostResponse
+            {
+                save = new GameSave
+                {
+                    id = 1,
+                    name = "Online Save",
+                    content = new SaveContent(new Dictionary<string, SavedObject>()),
+                    updatedAt = "2026-07-21T23:38:00.999Z"
+                }
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator LeadingCall_FiresOnSaveUpdated()
+        {
+            var api = BuildApiWithChosenSave(1, "Online Save");
+            Talo.Saves.OnSaveUpdated += _mock.OnUpdated;
+
+            var uri = new Uri(api.GetUri() + "/1");
+            RequestMock.ReplyOnce(uri, "PATCH", PatchedSaveJson());
+
+            _ = Talo.Saves.DebounceUpdate();
+
+            Assert.AreEqual(1, _mock.updatedCount);
+            Assert.IsTrue(_mock.lastSuccess);
+            Assert.IsNotNull(_mock.lastSave);
+            Assert.AreEqual(1, _mock.lastSave.id);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator LeadingAndTrailing_FireOnSaveUpdatedTwice()
+        {
+            var api = BuildApiWithChosenSave(1, "Online Save");
+            Talo.Saves.OnSaveUpdated += _mock.OnUpdated;
+
+            var uri = new Uri(api.GetUri() + "/1");
+            RequestMock.Reply(uri, "PATCH", PatchedSaveJson());
+
+            _ = Talo.Saves.DebounceUpdate();
+            _ = Talo.Saves.DebounceUpdate();
+
+            Assert.AreEqual(1, _mock.updatedCount);
+
+            var result = Talo.Saves.FlushUpdates().GetAwaiter().GetResult();
+            Assert.AreEqual(DebouncedAPIBase.FlushResult.Success, result);
+            Assert.AreEqual(2, _mock.updatedCount);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator HttpError_FiresOnSaveUpdatedWithFalse()
+        {
+            BuildApiWithChosenSave(1, "Online Save");
+            Talo.Saves.OnSaveUpdated += _mock.OnUpdated;
+
+            // no mock for update means the leading call's Debounce() fails
+            _ = Talo.Saves.DebounceUpdate();
+
+            Assert.AreEqual(1, _mock.updatedCount);
+            Assert.IsFalse(_mock.lastSuccess);
+            Assert.IsNull(_mock.lastSave);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TrailingCall_FailsOnHttpError_ReturnsFlushResultFailure()
+        {
+            var api = BuildApiWithChosenSave(1, "Online Save");
+            Talo.Saves.OnSaveUpdated += _mock.OnUpdated;
+
+            var uri = new Uri(api.GetUri() + "/1");
+            RequestMock.ReplyOnce(uri, "PATCH", PatchedSaveJson());
+
+            _ = Talo.Saves.DebounceUpdate();
+            _ = Talo.Saves.DebounceUpdate();
+
+            Assert.AreEqual(1, _mock.updatedCount);
+            Assert.IsTrue(_mock.lastSuccess);
+
+            // trailing call has no mock so flush returns Failure (not throw)
+            var flushResult = Talo.Saves.FlushUpdates().GetAwaiter().GetResult();
+            Assert.AreEqual(DebouncedAPIBase.FlushResult.Failure, flushResult);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator FlushUpdates_NoPending_ReturnsNothingPending()
+        {
+            BuildApiWithChosenSave(1, "Online Save");
+            var result = Talo.Saves.FlushUpdates().GetAwaiter().GetResult();
+            Assert.AreEqual(DebouncedAPIBase.FlushResult.NothingPending, result);
+            yield return null;
+        }
+    }
+}

--- a/Assets/Talo Game Services/Talo/Tests/SavesAPI/SaveUpdatedEventTest.cs.meta
+++ b/Assets/Talo Game Services/Talo/Tests/SavesAPI/SaveUpdatedEventTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 390c73ec4f144d189e64cef017111fa2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Assets/Talo Game Services/Talo/
 
 Follow the patterns established in existing API and entity files:
 
-- All API classes inherit from `BaseAPI` (or `DebouncedAPI<TOperation>` when debouncing is needed)
+- All API classes inherit from `BaseAPI` (or `DebouncedAPI` when debouncing is needed)
 - Use `async`/`await` for all network operations
 - Request and response types live in their respective `Requests/` and `Responses/` folders
 


### PR DESCRIPTION
**Debounced API overhaul**

- `DebouncedAPI` is now generic over `TReturnData` and `TUpdateResult`, enabling callers to receive typed results from debounced operations instead of fire-and-forget voids.
- `Player.SetProp`, `DeleteProp`, and their array variants now return `Task<PlayerUpdateResult>`, letting callers await the outcome and inspect rejected props inline.
- `Talo.Saves.UpdateCurrentSave` and `DebounceUpdate` now return `Task<SaveUpdateResult>` with the updated save on success.

**Completion signals and flush support**

- Added `OnPlayerUpdated(bool)` and `OnSaveUpdated(bool, GameSave)` events that fire after each debounced settle, so UI can react without polling.
- `FlushUpdates()` on both APIs drains any pending trailing calls and returns a `FlushResult` enum (`NothingPending`, `Success`, `Failure`).
- `TaloManager.OnApplicationQuit` now flushes events, player updates, and save updates before the process exits, preventing silent data loss.

**Sample and documentation updates**

- Playground `SetProp` sample now awaits the result and shows rejection reasons inline instead of relying on a global event listener.
- Saves demo subscribes to `OnSaveUpdated` for save feedback instead of manually toggling button text after awaiting.