### PR TITLE
Remove prop rejection events, keep them inline with update results

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/ChannelsAPI.cs
@@ -96,7 +96,6 @@ namespace TaloGameServices
         public event Action<Channel, PlayerAlias> OnOwnershipTransferred;
         public event Action<Channel> OnChannelDeleted;
         public event Action<Channel, string[]> OnChannelUpdated;
-        public event Action<RejectedProp[]> OnChannelPropsRejected;
         public event Action<Channel, RejectedProp[]> OnChannelStoragePropsFailedToSet;
         public event Action<Channel, ChannelStorageProp[], ChannelStorageProp[]> OnChannelStoragePropsUpdated;
 
@@ -170,7 +169,7 @@ namespace TaloGameServices
             return res.channels;
         }
 
-        private async Task<Channel> SendCreateChannelRequest(CreateChannelOptions options)
+        private async Task<ChannelUpsertResult> SendCreateChannelRequest(CreateChannelOptions options)
         {
             Talo.IdentityCheck();
 
@@ -191,19 +190,19 @@ namespace TaloGameServices
                 var json = await Call(uri, "POST", content);
 
                 var res = JsonUtility.FromJson<ChannelResponse>(json);
-                return res.channel;
+                return new ChannelUpsertResult(true, res.channel);
             }
             catch (RequestException ex)
             {
                 if (ex.IsBadRequest())
                 {
-                    RejectedProp.TryEmit(ex.responseBody, OnChannelPropsRejected);
+                    return new ChannelUpsertResult(false, null, RejectedProp.FromJson(ex.responseBody));
                 }
                 throw;
             }
         }
 
-        public async Task<Channel> Create(CreateChannelOptions options)
+        public async Task<ChannelUpsertResult> Create(CreateChannelOptions options)
         {
             options ??= new CreateChannelOptions();
             return await SendCreateChannelRequest(options);
@@ -228,7 +227,7 @@ namespace TaloGameServices
             await Call(uri, "POST");
         }
 
-        public async Task<Channel> Update(int channelId, UpdateChannelOptions options = null)
+        public async Task<ChannelUpsertResult> Update(int channelId, UpdateChannelOptions options = null)
         {
             Talo.IdentityCheck();
 
@@ -252,13 +251,13 @@ namespace TaloGameServices
                 var json = await Call(uri, "PUT", content);
 
                 var res = JsonUtility.FromJson<ChannelResponse>(json);
-                return res.channel;
+                return new ChannelUpsertResult(true, res.channel);
             }
             catch (RequestException ex)
             {
                 if (ex.IsBadRequest())
                 {
-                    RejectedProp.TryEmit(ex.responseBody, OnChannelPropsRejected);
+                    return new ChannelUpsertResult(false, null, RejectedProp.FromJson(ex.responseBody));
                 }
                 throw;
             }
@@ -399,6 +398,20 @@ namespace TaloGameServices
             }
 
             return Array.Empty<ChannelStorageProp>();
+        }
+
+        public class ChannelUpsertResult
+        {
+            public bool Success { get; }
+            public Channel Channel { get; }
+            public RejectedProp[] RejectedProps { get; }
+
+            public ChannelUpsertResult(bool success, Channel channel, RejectedProp[] rejectedProps = null)
+            {
+                Success = success;
+                Channel = channel;
+                RejectedProps = rejectedProps ?? Array.Empty<RejectedProp>();
+            }
         }
     }
 }

--- a/Assets/Talo Game Services/Talo/Runtime/APIs/FeedbackAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/FeedbackAPI.cs
@@ -7,8 +7,6 @@ namespace TaloGameServices
 {
     public class FeedbackAPI : BaseAPI
     {
-        public event Action<RejectedProp[]> OnPropsRejected;
-
         public FeedbackAPI() : base("v1/game-feedback") { }
 
         public async Task<FeedbackCategory[]> GetCategories()
@@ -20,7 +18,7 @@ namespace TaloGameServices
             return res.feedbackCategories;
         }
 
-        public async Task Send(string categoryInternalName, string comment, params (string, string)[] props)
+        public async Task<FeedbackSendResult> Send(string categoryInternalName, string comment, params (string, string)[] props)
         {
             Talo.IdentityCheck();
 
@@ -31,14 +29,27 @@ namespace TaloGameServices
             try
             {
                 await Call(uri, "POST", content);
+                return new FeedbackSendResult(true);
             }
             catch (RequestException ex)
             {
                 if (ex.IsBadRequest())
                 {
-                    RejectedProp.TryEmit(ex.responseBody, OnPropsRejected);
+                    return new FeedbackSendResult(false, RejectedProp.FromJson(ex.responseBody));
                 }
                 throw;
+            }
+        }
+
+        public class FeedbackSendResult
+        {
+            public bool Success { get; }
+            public RejectedProp[] RejectedProps { get; }
+
+            public FeedbackSendResult(bool success, RejectedProp[] rejectedProps = null)
+            {
+                Success = success;
+                RejectedProps = rejectedProps ?? Array.Empty<RejectedProp>();
             }
         }
     }

--- a/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/LeaderboardsAPI.cs
@@ -45,8 +45,6 @@ namespace TaloGameServices
     {
         private readonly LeaderboardEntriesManager _entriesManager = new();
 
-        public event Action<RejectedProp[]> OnPropsRejected;
-
         public LeaderboardsAPI() : base("v1/leaderboards") { }
 
         public List<LeaderboardEntry> GetCachedEntries(string internalName, GetCachedEntriesOptions options = null)
@@ -77,7 +75,7 @@ namespace TaloGameServices
             return res;
         }
 
-        public async Task<(LeaderboardEntry, bool)> AddEntry(string internalName, float score, params (string, string)[] propTuples)
+        public async Task<AddEntryResult> AddEntry(string internalName, float score, params (string, string)[] propTuples)
         {
             Talo.IdentityCheck();
 
@@ -93,15 +91,31 @@ namespace TaloGameServices
                 var res = JsonUtility.FromJson<LeaderboardEntryResponse>(json);
                 _entriesManager.UpsertEntry(internalName, res.entry, true);
 
-                return (res.entry, res.updated);
+                return new AddEntryResult(true, res.entry, res.updated);
             }
             catch (RequestException ex)
             {
                 if (ex.IsBadRequest())
                 {
-                    RejectedProp.TryEmit(ex.responseBody, OnPropsRejected);
+                    return new AddEntryResult(false, null, false, RejectedProp.FromJson(ex.responseBody));
                 }
                 throw;
+            }
+        }
+
+        public class AddEntryResult
+        {
+            public bool Success { get; }
+            public LeaderboardEntry Entry { get; }
+            public bool Updated { get; }
+            public RejectedProp[] RejectedProps { get; }
+
+            public AddEntryResult(bool success, LeaderboardEntry entry, bool updated, RejectedProp[] rejectedProps = null)
+            {
+                Success = success;
+                Entry = entry;
+                Updated = updated;
+                RejectedProps = rejectedProps ?? Array.Empty<RejectedProp>();
             }
         }
     }

--- a/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/APIs/PlayersAPI.cs
@@ -20,7 +20,6 @@ namespace TaloGameServices
         public event Action OnIdentificationStarted;
         public event Action<IdentifyException> OnIdentificationFailed;
         public event Action OnIdentityCleared;
-        public event Action<RejectedProp[]> OnPropsRejected;
         public event Action<bool> OnPlayerUpdated;
 
         public PlayersAPI() : base("v1/players")
@@ -174,11 +173,6 @@ namespace TaloGameServices
             var res = JsonUtility.FromJson<PlayersUpdateResponse>(json);
             Talo.CurrentPlayer = res.player;
             Talo.CurrentAlias.WriteOfflineAlias();
-
-            if (res.rejectedProps != null && res.rejectedProps.Length > 0)
-            {
-                OnPropsRejected?.Invoke(res.rejectedProps);
-            }
 
             return res.rejectedProps ?? Array.Empty<RejectedProp>();
         }

--- a/Assets/Talo Game Services/Talo/Runtime/Entities/RejectedProp.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/Entities/RejectedProp.cs
@@ -35,14 +35,6 @@ namespace TaloGameServices
             return wrapper?.rejectedProps ?? Array.Empty<RejectedProp>();
         }
 
-        public static void TryEmit(string json, Action<RejectedProp[]> onRejected)
-        {
-            var rejectedProps = FromJson(json);
-            if (rejectedProps.Length > 0)
-            {
-                onRejected?.Invoke(rejectedProps);
-            }
-        }
     }
 
     [Serializable]

--- a/Assets/Talo Game Services/Talo/Samples/ChannelStorageDemo/Scripts/ChannelStorageDemoUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/ChannelStorageDemo/Scripts/ChannelStorageDemoUIController.cs
@@ -65,7 +65,17 @@ namespace TaloGameServices.Sample.ChannelStorageDemo
                         ("channel-storage-demo", "true")
                     }
                 };
-                demoChannel = await Talo.Channels.Create(createOptions);
+                var createResult = await Talo.Channels.Create(createOptions);
+                if (createResult.Success)
+                {
+                    demoChannel = createResult.Channel;
+                }
+            }
+
+            if (demoChannel == null)
+            {
+                Debug.LogError("Failed to create or find a channel for the Channel Storage Demo");
+                return;
             }
 
             await Talo.Channels.Join(demoChannel.id);

--- a/Assets/Talo Game Services/Talo/Samples/ChatDemo/Scripts/ChatUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/ChatDemo/Scripts/ChatUIController.cs
@@ -132,7 +132,9 @@ namespace TaloGameServices.Sample.ChatDemo
                 return;
             }
 
-            var channel = await Talo.Channels.Create(new CreateChannelOptions() { name = channelName, autoCleanup = true });
+            var result = await Talo.Channels.Create(new CreateChannelOptions() { name = channelName, autoCleanup = true });
+
+            var channel = result.Channel;
             AddChannelToList(channel);
             channelNameField.value = "";
             activeChannelId = channel.id;

--- a/Assets/Talo Game Services/Talo/Samples/LeaderboardsDemo/Scripts/LeaderboardUIController.cs
+++ b/Assets/Talo Game Services/Talo/Samples/LeaderboardsDemo/Scripts/LeaderboardUIController.cs
@@ -42,14 +42,14 @@ namespace TaloGameServices.Sample.LeaderboardsDemo
             var team = UnityEngine.Random.Range(0, 2) == 0 ? "Blue" : "Red";
 
             await Talo.Players.Identify("username", username);
-            (LeaderboardEntry entry, bool updated) = await Talo.Leaderboards.AddEntry(
+            var result = await Talo.Leaderboards.AddEntry(
                 leaderboardName,
                 score,
                 ("team", team)
             );
 
             infoLabel.text = $"You scored {score} for the {team} team.";
-            if (updated) infoLabel.text += " Your highscore was updated!";
+            if (result.Updated) infoLabel.text += " Your highscore was updated!";
 
             entriesList.Rebuild();
         }

--- a/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Feedback/SendFeedback.cs
+++ b/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Feedback/SendFeedback.cs
@@ -17,8 +17,15 @@ namespace TaloGameServices.Sample.Playground
 
             try
             {
-                await Talo.Feedback.Send(categoryInternalName, feedbackComment);
-                ResponseMessage.SetText($"Feedback sent for {categoryInternalName}: {feedbackComment}");
+                var result = await Talo.Feedback.Send(categoryInternalName, feedbackComment);
+                if (result.Success)
+                {
+                    ResponseMessage.SetText($"Feedback sent for {categoryInternalName}: {feedbackComment}");
+                }
+                else
+                {
+                    ResponseMessage.SetText("Failed to send feedback");
+                }
             }
             catch (Exception ex)
             {

--- a/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Leaderboards/PostLeaderboardEntry.cs
+++ b/Assets/Talo Game Services/Talo/Samples/Playground/Scripts/Leaderboards/PostLeaderboardEntry.cs
@@ -24,9 +24,15 @@ namespace TaloGameServices.Sample.Playground
             try
             {
                 int score = UnityEngine.Random.Range(0, 10000);
-                (LeaderboardEntry entry, bool updated) = await Talo.Leaderboards.AddEntry(leaderboardInternalName, score);
+                var result = await Talo.Leaderboards.AddEntry(leaderboardInternalName, score);
 
-                ResponseMessage.SetText($"Entry with score {score} added, position is {entry.position}, it was {(updated ? "" : "not")} updated");
+                if (result.Entry == null)
+                {
+                    ResponseMessage.SetText("Failed to add entry");
+                    return;
+                }
+
+                ResponseMessage.SetText($"Entry with score {score} added, position is {result.Entry.position}, it was {(result.Updated ? "" : "not")} updated");
             }
             catch (Exception ex)
             {

--- a/Assets/Talo Game Services/Talo/Tests/PlayersAPI/PlayerUpdatedEventTest.cs
+++ b/Assets/Talo Game Services/Talo/Tests/PlayersAPI/PlayerUpdatedEventTest.cs
@@ -99,14 +99,9 @@ namespace TaloGameServices.Test
         }
 
         [UnityTest]
-        public IEnumerator PropRejection_BothOnPropsRejectedAndOnPlayerUpdatedFire()
+        public IEnumerator PropRejection_OnPlayerUpdatedFiresWithRejectedProps()
         {
-            int rejectedCount = 0;
             Talo.Players.OnPlayerUpdated += _mock.OnUpdated;
-            Talo.Players.OnPropsRejected += _ =>
-            {
-                rejectedCount++;
-            };
 
             var uri = new Uri($"{Talo.Settings.apiUrl}/v1/players/uuid");
             RequestMock.ReplyOnce(uri, "PATCH", JsonUtility.ToJson(new PlayersUpdateResponse
@@ -115,9 +110,10 @@ namespace TaloGameServices.Test
                 rejectedProps = new[] { new RejectedProp { key = "k1", error = "PROP_VALUE_TOO_LONG", message = "too long" } }
             }));
 
-            Talo.CurrentPlayer.SetProp("k1", "v1-updated");
+            var result = Talo.CurrentPlayer.SetProp("k1", "v1-updated").GetAwaiter().GetResult();
 
-            Assert.AreEqual(1, rejectedCount);
+            Assert.AreEqual(1, result.RejectedProps.Length);
+            Assert.AreEqual("k1", result.RejectedProps[0].key);
             Assert.AreEqual(1, _mock.updatedCount);
             Assert.IsTrue(_mock.lastSuccess);
 


### PR DESCRIPTION
**Result types replacing event-based error handling**

- `ChannelsAPI.Create` and `Update` now return `ChannelUpsertResult` instead of `Channel` directly, wrapping success/failure status, the channel, and any rejected props.
- `FeedbackAPI.Send` now returns `FeedbackSendResult` instead of void, including success status and rejected props.
- `LeaderboardsAPI.AddEntry` now returns `AddEntryResult` instead of a tuple `(LeaderboardEntry, bool)`, adding success status and rejected props.
- `PlayersAPI` no longer fires `OnPropsRejected` separately; rejected props are returned directly via `SetProp` and the existing `OnPlayerUpdated` event.

**Removal of RejectedProp event emissions**

- `RejectedProp.TryEmit` was removed entirely, as the pattern of emitting rejected props via events is no longer used.
- `OnChannelPropsRejected` and `OnPropsRejected` events were removed from `ChannelsAPI`, `FeedbackAPI`, `LeaderboardsAPI`, and `PlayersAPI`.

**Sample updates for new API shapes**

- All sample/demo scripts were updated to work with the new result types, checking `Success`/`Entry` properties instead of relying on events or tuples.