### PR TITLE
Make default debounce time 0.5 seconds

### DIFF
--- a/Assets/Talo Game Services/Talo/Runtime/TaloSettings.cs
+++ b/Assets/Talo Game Services/Talo/Runtime/TaloSettings.cs
@@ -36,7 +36,7 @@ namespace TaloGameServices
         public bool cachePlayerOnIdentify = true;
 
         [Tooltip("Number of seconds to wait before sending debounced requests (e.g. player updates, save updates and health checks)")]
-        public float debounceTimerSeconds = 1f;
+        public float debounceTimerSeconds = 0.5f;
 
         [Tooltip("Enable request verification to prevent replay attacks and tampering - this must also be enabled in the dashboard")]
         public bool verificationEnabled = false;


### PR DESCRIPTION
**Debounce timing reduction**
- Default debounce timer for player updates, save updates, and health checks lowered from 1 second to 0.5 seconds, making the SDK feel more responsive during rapid changes.